### PR TITLE
Revert "Allow containers with TTY enabled"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ This is a fork of logspout, with the following changed merged in:
 - Filter containers by label: https://github.com/gliderlabs/logspout/pull/236
 - HTTP adapter: https://github.com/raychaser/logspout-http
 - HTTP adapter can forward container labels
-- Allow containers with TTY enabled (see https://github.com/gliderlabs/logspout/issues/72) using `-e ALLOW_TTY=true`
 
 [![CircleCI](https://img.shields.io/circleci/project/gliderlabs/logspout/release.svg)](https://circleci.com/gh/gliderlabs/logspout)
 [![Docker Hub](https://img.shields.io/badge/docker-ready-blue.svg)](https://registry.hub.docker.com/u/gliderlabs/logspout/)

--- a/router/pump.go
+++ b/router/pump.go
@@ -153,11 +153,8 @@ func (p *LogsPump) pumpLogs(event *docker.APIEvents, backlog bool) {
 	container, err := p.client.InspectContainer(id)
 	assert(err, "pump")
 	if container.Config.Tty {
-		allowTty := getopt("ALLOW_TTY", "")
-   		if (allowTty != "true") {
-			debug("pump.pumpLogs():", id, "ignored: tty enabled")
-			return
-		}
+		debug("pump.pumpLogs():", id, "ignored: tty enabled")
+		return
 	}
 	if ignoreContainer(container) {
 		debug("pump.pumpLogs():", id, "ignored: environ ignore")


### PR DESCRIPTION
There was a bug with this that needs to be resolved. We can fix it later, but let's get master back to stable